### PR TITLE
feat: add mousetrap 'action' parameter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ type HotkeyShortcuts = {
   ref?: any;
   hidden?: boolean;
   callback: (e: ExtendedKeyboardEvent, combo: string) => void;
+  action?: 'keypress'| 'keydown'| 'keyup';
 }
 ```
 

--- a/src/Hotkey.story.tsx
+++ b/src/Hotkey.story.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import { useHotkeys } from './useHotkeys';
 
 export default {
-  title: 'Hotkeys'
+  title: 'Hotkeys',
 };
 
 export const Simple = () => {
@@ -33,15 +33,18 @@ export const Refs = () => {
       keys: 'SHIFT+A',
       callback: () => {
         alert(`color: ${color}`);
-      }
-    }
+      },
+    },
   ]);
 
   return (
     <div>
       Press SHIFT + A<br />
-      Color: {color}<br />
-      <button type="button" onClick={() => setColor('yellow')}>Change Color</button>
+      Color: {color}
+      <br />
+      <button type="button" onClick={() => setColor('yellow')}>
+        Change Color
+      </button>
       <pre>
         {JSON.stringify(
           hotkeys.map(({ ref: element, ...rest }) => rest),
@@ -94,7 +97,8 @@ export const Nested = () => {
   return (
     <div>
       Press SHIFT + A<br />
-      <NestedComponent /><br />
+      <NestedComponent />
+      <br />
       <br />
       <pre>
         {JSON.stringify(
@@ -139,6 +143,31 @@ export const Focus = () => {
       <span ref={elmRef2} tabIndex={-1}>
         focus me and press SHIFT+C
       </span>
+      <br />
+      <pre>
+        {JSON.stringify(
+          hotkeys.map(({ ref: element, ...rest }) => rest),
+          null,
+          2
+        )}
+      </pre>
+    </div>
+  );
+};
+
+export const Action = () => {
+  const hotkeys = useHotkeys([
+    {
+      name: 'Pay respects',
+      keys: 'f',
+      callback: (e) => alert("You've been promoted!"),
+      action: 'keyup',
+    },
+  ]);
+
+  return (
+    <div>
+      Press f to pay respects
       <br />
       <pre>
         {JSON.stringify(

--- a/src/useHotkeyState.ts
+++ b/src/useHotkeyState.ts
@@ -9,6 +9,7 @@ export type HotkeyShortcuts = {
   ref?: any;
   hidden?: boolean;
   callback: (e: ExtendedKeyboardEvent, combo: string) => void;
+  action?: 'keypress' | 'keydown' | 'keyup';
 };
 
 /**
@@ -22,7 +23,7 @@ const createStateHook = () => {
 
     nextKeys.forEach((k) => {
       const mousetrap = k.ref?.current ? Mousetrap(k.ref.current) : Mousetrap;
-      mousetrap.bind(k.keys, k.callback);
+      mousetrap.bind(k.keys, k.callback, k.action);
     });
   };
 
@@ -30,7 +31,7 @@ const createStateHook = () => {
     keys = keys.filter((k) => !nextKeys.includes(k));
 
     nextKeys.forEach((s) => {
-      Mousetrap.unbind(s.keys);
+      Mousetrap.unbind(s.keys, s.action);
     });
   };
 
@@ -39,14 +40,14 @@ const createStateHook = () => {
 
     useEffect(() => {
       setState(keys);
-    }, [])
+    }, []);
 
     return [state, addKeys, removeKeys] as [
       HotkeyShortcuts[],
       (keys: HotkeyShortcuts[]) => void,
       (keys: HotkeyShortcuts[]) => void
     ];
-  }
+  };
 };
 
 export const useHotkeyState = createStateHook();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- ❎ Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Support mousetrap `action` parameter documented [here](https://craig.is/killing/mice#api.bind.single), to specify the type of event to listen for.

Story added for tests.

README updated to reflect that possibility.

Issue Number: N/A


## What is the new behavior?
you can now specify which type of event will trigger the callback.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

