### PR TITLE
Cache the specific Mousetrap used for each HotkeyShortcuts

### DIFF
--- a/src/useHotkeyState.ts
+++ b/src/useHotkeyState.ts
@@ -52,7 +52,7 @@ const createStateHook = () => {
 
   const removeKeys = (nextKeys: HotkeyShortcuts[]) => {
     keys = keys.filter((k) => !nextKeys.includes(k));
-    nextKeys.forEach(s => (shortcutMousetraps.get(s) ?? getMousetrap(s.ref?.current)).unbind(s.keys, s.action));
+    nextKeys.forEach(s => shortcutMousetraps.get(s)?.unbind(s.keys, s.action));
   };
 
   return () => {

--- a/src/useHotkeyState.ts
+++ b/src/useHotkeyState.ts
@@ -30,6 +30,8 @@ const getMousetrap = (element: HTMLElement | null | undefined): MousetrapInstanc
   return Mousetrap;
 }
 
+const shortcutMousetraps: WeakMap<HotkeyShortcuts, MousetrapInstance | MousetrapStatic> = new WeakMap();
+
 /**
  * Creates a global state singleton.
  */
@@ -41,14 +43,16 @@ const createStateHook = () => {
 
     nextKeys.forEach((k) => {
       if (!k.disabled) {
-        getMousetrap(k.ref?.current).bind(k.keys, k.callback, k.action);
+        const mousetrap = getMousetrap(k.ref?.current);
+        shortcutMousetraps.set(k, mousetrap);
+        mousetrap.bind(k.keys, k.callback, k.action);
       }
     });
   };
 
   const removeKeys = (nextKeys: HotkeyShortcuts[]) => {
     keys = keys.filter((k) => !nextKeys.includes(k));
-    nextKeys.forEach(s => Mousetrap.unbind(s.keys, s.action));
+    nextKeys.forEach(s => (shortcutMousetraps.get(s) ?? getMousetrap(s.ref?.current)).unbind(s.keys, s.action));
   };
 
   return () => {


### PR DESCRIPTION
Today on random bugsquashing, I change completely unrelated things while trying to figure out why my shortcuts are being duplicated.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
1. unbind is called on the global mousetrap instead of the element-specific one
2. without caching, if (1) was fixed, then UB if `ref` changes (I _hate_ that you made it accept a ref instead of a straight HTMLElement.)

Issue Number: N/A

## What is the new behavior?
1. unbind is always called on the same Mousetrap that bind was called on, and is only called if the shortcut was bound in the first place, guaranteed.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```