### PR TITLE
Restore previously overwritten listeners

### DIFF
--- a/src/Hotkey.story.tsx
+++ b/src/Hotkey.story.tsx
@@ -244,3 +244,82 @@ export const Asynchronous = () => {
     </div>
   );
 };
+
+const Counter = () => {
+  const [counter, setCounter] = useState(0);
+  const hotkeys = useHotkeys([
+    {
+      name: 'Generate a random number',
+      keys: 'g',
+      callback: () => setCounter(Math.random()),
+    },
+  ]);
+
+  return (
+    <div>
+      <ol>
+        <li>Press "g" to generate a random number: {counter}</li>
+        <li>Open the modal, press "g" and close the modal</li>
+        <li>
+          Press "g" once the modal is closed, it should generate random number
+        </li>
+      </ol>
+      <br />
+      <pre>{JSON.stringify(hotkeys, null, 2)}</pre>
+    </div>
+  );
+};
+
+const ModalComponent = ({ onClose }: { onClose: () => void }) => {
+  const hotkeys = useHotkeys([
+    {
+      name: 'Modal shortcut',
+      keys: 'g',
+      callback: () => alert('This shortcut is bound through the modal'),
+    },
+  ]);
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: `translate(-50%,-50%)`,
+        backgroundColor: `rgba(0,0,0,0.4)`,
+      }}
+    >
+      <div style={{ padding: '10px', backgroundColor: 'white' }}>
+        <button type="button" onClick={onClose}>
+          Close Modal
+        </button>
+        <br />
+        <p>Press g</p>
+        <br />
+        <pre>{JSON.stringify(hotkeys, null, 2)}</pre>
+      </div>
+    </div>
+  );
+};
+
+const ModalToggle = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setIsOpen(true)}>
+        Open Modal
+      </button>
+      {isOpen && <ModalComponent onClose={() => setIsOpen(false)} />}
+    </div>
+  );
+};
+
+export const Modal = () => {
+  return (
+    <div>
+      <Counter />
+      <ModalToggle />
+    </div>
+  );
+};

--- a/src/useHotkeyState.ts
+++ b/src/useHotkeyState.ts
@@ -20,9 +20,7 @@ const createStateHook = () => {
   const mousetraps = new Map<HTMLElement | undefined, MousetrapInstance>();
   let keys: HotkeyShortcuts[] = [];
 
-  const addKeys = (nextKeys: HotkeyShortcuts[]) => {
-    keys = [...keys, ...nextKeys];
-
+  const bindKeys = (nextKeys: HotkeyShortcuts[]) => {
     nextKeys.forEach((k) => {
       if (k.disabled) {
         return;
@@ -50,6 +48,12 @@ const createStateHook = () => {
         mousetraps.get(undefined)!.bind(k.keys, k.callback, k.action);
       }
     });
+  };
+
+  const addKeys = (nextKeys: HotkeyShortcuts[]) => {
+    keys = [...keys, ...nextKeys];
+
+    bindKeys(nextKeys);
   };
 
   const removeKeys = (nextKeys: HotkeyShortcuts[]) => {
@@ -83,6 +87,9 @@ const createStateHook = () => {
 
       mousetraps.delete(element);
     }
+
+    // re-bind keys to restore listeners that were overwritten by the ones we just removed
+    bindKeys(keys);
   };
 
   return () => {


### PR DESCRIPTION
I added a story that showcases the bug which is now fixed. Listeners are properly re-bound when removing some.

Fix #16 

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] ~Docs have been added / updated (for bug fixes / features)~

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```