### PR TITLE
Make global events compatible with Mousetrap.trigger

### DIFF
--- a/src/Hotkey.story.tsx
+++ b/src/Hotkey.story.tsx
@@ -1,3 +1,4 @@
+import Mousetrap from 'mousetrap';
 import React, { useEffect, useRef, useState } from 'react';
 import { useHotkeys } from './useHotkeys';
 
@@ -320,6 +321,28 @@ export const Modal = () => {
     <div>
       <Counter />
       <ModalToggle />
+    </div>
+  );
+};
+
+export const Trigger = () => {
+  const hotkeys = useHotkeys([
+    { name: 'Test', keys: 'SHIFT+A', callback: () => alert('holla') },
+  ]);
+
+  return (
+    <div>
+      <button type="button" onClick={() => Mousetrap.trigger('SHIFT+A')}>
+        Trigger shift+a
+      </button>
+      Press SHIFT + A<br />
+      <pre>
+        {JSON.stringify(
+          hotkeys.map(({ ref: element, ...rest }) => rest),
+          null,
+          2
+        )}
+      </pre>
     </div>
   );
 };

--- a/src/useHotkeyState.ts
+++ b/src/useHotkeyState.ts
@@ -1,5 +1,9 @@
 import { RefObject, useEffect, useState } from 'react';
-import Mousetrap, { ExtendedKeyboardEvent, MousetrapInstance } from 'mousetrap';
+import Mousetrap, {
+  ExtendedKeyboardEvent,
+  MousetrapInstance,
+  MousetrapStatic,
+} from 'mousetrap';
 
 export interface HotkeyShortcuts {
   name: string;
@@ -17,7 +21,10 @@ export interface HotkeyShortcuts {
  * Creates a global state singleton.
  */
 const createStateHook = () => {
-  const mousetraps = new Map<HTMLElement | undefined, MousetrapInstance>();
+  const mousetraps = new Map<
+    HTMLElement | undefined,
+    MousetrapStatic | MousetrapInstance
+  >();
   let keys: HotkeyShortcuts[] = [];
 
   const bindKeys = (nextKeys: HotkeyShortcuts[]) => {
@@ -42,7 +49,7 @@ const createStateHook = () => {
         mousetraps.get(element)!.bind(k.keys, k.callback, k.action);
       } else {
         if (!mousetraps.get(undefined)) {
-          mousetraps.set(undefined, new Mousetrap());
+          mousetraps.set(undefined, Mousetrap);
         }
 
         mousetraps.get(undefined)!.bind(k.keys, k.callback, k.action);


### PR DESCRIPTION
Follow up to https://github.com/reaviz/reakeys/pull/21#issuecomment-1190184720

The mousetrap instances are not exposed so there's no way to call their `trigger` methods for now. It can be worked around by using the `Mousetrap` object for global events.