### PR TITLE
Don't `console.warn()` when `navigator` is `undefined`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
 let isMac: boolean = false;
 try {
-  if (navigator) isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-} catch (e) {
-  console.warn(e);
+  isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+} catch {
+  // Ignore
 }
 
 export const MODIFIER_KEY = isMac ? '⌘' : 'CTRL';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,15 +1,22 @@
-let isMac: boolean = false;
-try {
-  isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-} catch {
-  // Ignore
+type ModifierKey = '⌘' | 'CTRL';
+
+function isMac(): boolean {
+  try {
+    return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+  } catch {
+    return false;
+  }
 }
 
-export const MODIFIER_KEY = isMac ? '⌘' : 'CTRL';
+function getModifierKey(): ModifierKey {
+  isMac() ? '⌘' : 'CTRL'
+}
+
+export const MODIFIER_KEY = getModifierKey();
 
 export function getHotkeyText(hotkey: string) {
   return hotkey
-    .replace('modifier', MODIFIER_KEY)
-    .replace('mod', MODIFIER_KEY)
+    .replace('modifier', getModifierKey())
+    .replace('mod', getModifierKey())
     .replace('shift', '⇧');
 }


### PR DESCRIPTION
`navigator` is expected to be `undefined` during SSR in React / Next.js.

Writing to the console pollutes the logs and makes it harder to spot real warnings/errors.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) — N/A
- [ ] Docs have been added / updated (for bug fixes / features) — N/A

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using [REAFLOW](https://reaflow.dev), and a parent component is Server-Side Rendered (e.g., by Next.js 14), the following error is printed to the console:

```
ReferenceError: navigator is not defined
    at eval (webpack-internal:///(ssr)/./node_modules/reakeys/dist/index.js:105:3)
    at (ssr)/./node_modules/reakeys/dist/index.js (./.next/server/vendor-chunks/reakeys.js:20:1)
    at __webpack_require__ (./.next/server/webpack-runtime.js:33:43)
    at eval (webpack-internal:///(ssr)/./node_modules/reaflow/dist/index.js:60:66)
    at (ssr)/./node_modules/reaflow/dist/index.js (./.next/server/vendor-chunks/reaflow.js:30:1)
    at __webpack_require__ (./.next/server/webpack-runtime.js:33:43)
```

This happens because `reakeys` [tries to access the global `navigator` object statically](https://github.com/reaviz/reakeys/blob/1862b580e069f2407dcf5667ab8ac2d1467e5d6f/src/utils.ts#L3) at module initialization time, which will never succeed on the server:

```ts
let isMac: boolean = false;
try {
  if (navigator) isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
} catch (e) {
  console.warn(e); // <!------------------
}

export const MODIFIER_KEY = isMac ? '⌘' : 'CTRL';

export function getHotkeyText(hotkey: string) {
  return hotkey
    .replace('modifier', MODIFIER_KEY)
    .replace('mod', MODIFIER_KEY)
    .replace('shift', '⇧');
}
```

And since [REAFLOW imports `reakeys`](https://github.com/reaviz/reaflow/blob/b9668444e3a1cd51598b110c502f7f49c4220727/src/helpers/useSelection.ts#L2), the `navigator` warning is triggered on every (dynamically-rendered) page load.

## What is the new behavior?

No error is printed to the console during SSR.

***No functionality has changed; only console logging has changed.***

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
