### PR TITLE
Use named export for ctrl-keys to fix CommonJS/UMD issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "ctrl-keys": "^1.0.3"
+        "ctrl-keys": "^1.0.6"
       },
       "devDependencies": {
         "@storybook/addon-docs": "^7.0.20",
@@ -8428,9 +8428,10 @@
       "dev": true
     },
     "node_modules/ctrl-keys": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ctrl-keys/-/ctrl-keys-1.0.3.tgz",
-      "integrity": "sha512-Kcb05/xUNra57fxpsLOflECWYbjQEQ9ZuQEthB3cgESN5zMLJ364twA9h2kqz8n06RnTY/+rKWM3UbkOWKeEJg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ctrl-keys/-/ctrl-keys-1.0.6.tgz",
+      "integrity": "sha512-fENSKrbIfvX83uHxruP3S/9GizirvgT66vHhgKHOCTVHK+22Xpud/vttg5c5IifRl+6Gom/GjE+ZSXJKf0DMTA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/reaviz/reakeys#readme",
   "dependencies": {
-    "ctrl-keys": "^1.0.3"
+    "ctrl-keys": "^1.0.6"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -1,6 +1,6 @@
 import { RefObject, useEffect, useLayoutEffect, useState } from 'react';
 import type { Callback, HandlerInterface, Key } from 'ctrl-keys';
-import keys from 'ctrl-keys';
+import { keys } from 'ctrl-keys';
 
 type Keys = [Key] | [Key, Key] | [Key, Key, Key] | [Key, Key, Key, Key];
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #33 

## What is the new behavior?

Using the named export instead of the default one solves the issue

```js
const ctrlKeys = require('ctrl-keys')

ctrlKeys.keys() // this now points to the function and works
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
