### PR TITLE
Add MOD alias for meta and ctrl keys

### DIFF
--- a/src/Hotkey.story.tsx
+++ b/src/Hotkey.story.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useHotkeys } from './useHotkeys';
+import { getHotkeyText } from './utils';
 
 export default {
   title: 'Hotkeys',
@@ -97,6 +98,7 @@ export const Multiple = () => {
   const hotkeys = useHotkeys([
     { name: 'Nested A', keys: ['SHIFT+A'], callback: () => alert('SHIFT + A pressed') },
     { name: 'Nested B', keys: ['META+B'], callback: () => alert('META + B pressed') },
+    { name: 'Nested F', keys: ['META+F'], callback: () => alert('META + F pressed') },
   ]);
 
   return (
@@ -104,6 +106,37 @@ export const Multiple = () => {
       Press SHIFT + A
       <br />
       Press META + B
+      <br />
+      <pre>
+        {JSON.stringify(
+          hotkeys.map(({ ref: element, ...rest }) => rest),
+          null,
+          2
+        )}
+      </pre>
+    </div>
+  );
+};
+
+export const ModifierAlias = () => {
+  const hotkeys = useHotkeys([
+    { name: 'Mod + A', keys: ['MOD+A'], action: 'keydown', callback: () => alert('Mod + A pressed') },
+    {
+      name: 'Mod + F',
+      keys: ['MOD+F'],
+      action: 'keydown',
+      callback: (event) => {
+        event?.preventDefault();
+        alert('Mod + F pressed');
+      },
+    },
+  ]);
+
+  return (
+    <div>
+      Press {getHotkeyText('MOD+A')}
+      <br />
+      Press {getHotkeyText('MOD+F')}
       <br />
       <pre>
         {JSON.stringify(

--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -1,6 +1,7 @@
 import { RefObject, useEffect, useLayoutEffect, useState } from 'react';
 import type { Callback, HandlerInterface, Key } from 'ctrl-keys';
 import { keys } from 'ctrl-keys';
+import { isMac } from './utils';
 
 type Keys = [Key] | [Key, Key] | [Key, Key, Key] | [Key, Key, Key, Key];
 
@@ -29,7 +30,10 @@ const handlers = new Map<HTMLElement, HandlerInterface>();
 let hotkeys: HotkeyShortcuts[] = [];
 
 const extractKeys = (keys: string | string[]): Keys => {
-  return (Array.isArray(keys) ? keys.map((key) => key.toLowerCase()) : [keys.toLowerCase()]) as Keys;
+  const normalizedKeys = Array.isArray(keys) ? keys.map((key) => key.toLowerCase()) : [keys.toLowerCase()];
+  const modKey = isMac() ? 'meta' : 'ctrl';
+
+  return normalizedKeys.map((key) => key.replace('modifier', modKey).replace('mod', modKey)) as Keys;
 };
 
 const focusInputWrapper = (callback: Callback) => (event: any) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 type ModifierKey = '⌘' | 'CTRL';
 
-function isMac(): boolean {
+export function isMac(): boolean {
   try {
     return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
   } catch {
@@ -15,5 +15,5 @@ function getModifierKey(): ModifierKey {
 export const MODIFIER_KEY = getModifierKey();
 
 export function getHotkeyText(hotkey: string) {
-  return hotkey.replace('modifier', getModifierKey()).replace('mod', getModifierKey()).replace('shift', '⇧');
+  return hotkey.toLowerCase().replace('modifier', getModifierKey()).replace('mod', getModifierKey()).replace('shift', '⇧');
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Mod key alias is missing (was handled by mousetrap before migration on ctrl-keys)

Issue Number: N/A


## What is the new behavior?
Added alias for 'mod' key to define one shortcut for Mac and Windows 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
