### PR TITLE
guard against keyless key events crashing hotkey handlers

### DIFF
--- a/src/useHotkeys.ts
+++ b/src/useHotkeys.ts
@@ -1,7 +1,7 @@
 import { RefObject, useEffect, useLayoutEffect, useState } from 'react';
 import type { Callback, HandlerInterface, Key } from 'ctrl-keys';
 import { keys } from 'ctrl-keys';
-import { isMac } from './utils';
+import { ignoreKeylessEvents, isMac } from './utils';
 
 type Keys = [Key] | [Key, Key] | [Key, Key, Key] | [Key, Key, Key, Key];
 
@@ -26,7 +26,7 @@ const keydownGlobalHandler = keys();
 /**
  * Map of specific elements handlers
  */
-const handlers = new Map<HTMLElement, HandlerInterface>();
+const handlers = new Map<HTMLElement, { handler: HandlerInterface; listener: (event: KeyboardEvent) => void }>();
 let hotkeys: HotkeyShortcuts[] = [];
 
 const extractKeys = (keys: string | string[]): Keys => {
@@ -76,17 +76,20 @@ const registerElementShortcut = (shortcut: HotkeyShortcuts) => {
 
   handler.add(...extractKeys(shortcut.keys), shortcut.callback);
 
-  shortcut.ref?.current?.addEventListener(shortcut.action ?? 'keypress', handler.handle);
+  const listener = ignoreKeylessEvents(handler.handle);
+  shortcut.ref?.current?.addEventListener(shortcut.action ?? 'keypress', listener);
 
-  handlers.set(shortcut.ref?.current as HTMLElement, handler);
+  handlers.set(shortcut.ref?.current as HTMLElement, { handler, listener });
 };
 
 const removeElementShortcut = (shortcut: HotkeyShortcuts) => {
   if (shortcut.ref?.current && !shortcut.disabled) {
-    const handler = handlers.get(shortcut.ref?.current) as HandlerInterface;
+    const entry = handlers.get(shortcut.ref?.current);
 
-    handler?.remove(...extractKeys(shortcut.keys), shortcut.callback);
-    shortcut.ref?.current?.removeEventListener(shortcut.action ?? 'keypress', handler.handle);
+    entry?.handler.remove(...extractKeys(shortcut.keys), shortcut.callback);
+    if (entry) {
+      shortcut.ref?.current?.removeEventListener(shortcut.action ?? 'keypress', entry.listener);
+    }
   }
 };
 
@@ -97,9 +100,9 @@ export const useHotkeys = (shortcuts: HotkeyShortcuts[] = []) => {
    */
   useLayoutEffect(() => {
     if (!isGlobalListenersBinded && window !== undefined) {
-      window.addEventListener('keypress', keypressGlobalHandler.handle);
-      window.addEventListener('keyup', keyupGlobalHandler.handle);
-      window.addEventListener('keydown', keydownGlobalHandler.handle);
+      window.addEventListener('keypress', ignoreKeylessEvents(keypressGlobalHandler.handle));
+      window.addEventListener('keyup', ignoreKeylessEvents(keyupGlobalHandler.handle));
+      window.addEventListener('keydown', ignoreKeylessEvents(keydownGlobalHandler.handle));
 
       isGlobalListenersBinded = true;
     }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ignoreKeylessEvents } from './utils';
+
+describe('ignoreKeylessEvents', () => {
+  it('ignores key events that carry no key, instead of crashing downstream', () => {
+    const handle = vi.fn();
+    const guarded = ignoreKeylessEvents(handle);
+
+    // Shape dispatched by some browser extensions / password managers; the
+    // underlying handler would otherwise do `event.key.toLowerCase()` and throw.
+    guarded({ key: undefined } as unknown as KeyboardEvent);
+    guarded({} as unknown as KeyboardEvent);
+
+    expect(handle).not.toHaveBeenCalled();
+  });
+
+  it('forwards real key events to the wrapped handler', () => {
+    const handle = vi.fn();
+    const guarded = ignoreKeylessEvents(handle);
+    const event = { key: 'k' } as KeyboardEvent;
+
+    guarded(event);
+
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenCalledWith(event);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,3 +17,20 @@ export const MODIFIER_KEY = getModifierKey();
 export function getHotkeyText(hotkey: string) {
   return hotkey.toLowerCase().replace('modifier', getModifierKey()).replace('mod', getModifierKey()).replace('shift', '⇧');
 }
+
+/**
+ * The key-matching handler reads `event.key.toLowerCase()` with no guard, so a
+ * key event whose `key` is missing throws a TypeError out of our key
+ * listeners. Some browser extensions and password managers dispatch synthetic
+ * key events with no `key`, so wrap the handler to ignore those; real
+ * keystrokes always carry a `key`.
+ */
+export const ignoreKeylessEvents =
+  (handle: (event: KeyboardEvent) => void) =>
+  (event: KeyboardEvent): void => {
+    if (event.key == null) {
+      return;
+    }
+
+    handle(event);
+  };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`ctrl-keys` calls `event.key.toLowerCase()` with no guard. Some browser extensions and password managers dispatch synthetic key events with no `key`, which throws a `TypeError` out of our listeners and breaks all hotkeys on the page.

## What is the new behavior?
guard against keyless keyboard events crashing hotkey handlers.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- adds `ignoreKeylessEvents`, a small wrapper that drops events without a `key` before they reach `ctrl-keys`.
- applies it to both the global window listeners and the element-scoped listener. The `handlers` map now stores the wrapped listener alongside its handler so `removeEventListener` detaches the same reference.
- adds unit tests for the guard.
- `npm test` — passes
- `tsc --noEmit` / `npm run lint` — clean